### PR TITLE
Add composed_with field for easy interface

### DIFF
--- a/lib/vandelay.rb
+++ b/lib/vandelay.rb
@@ -1,5 +1,6 @@
-require "vandelay/version"
-require "vandelay/buildable"
+require "vandelay/version".freeze
+require "vandelay/buildable".freeze
+require "vandelay/compose_from".freeze
 
 module Vandelay
 end

--- a/lib/vandelay/compose_from.rb
+++ b/lib/vandelay/compose_from.rb
@@ -1,0 +1,48 @@
+module Vandelay
+  module ComposeFrom
+    def self.extended(base)
+      base.extend ClassMethods
+      base.define_singleton_method(:compose_from) do |from_name, attributes|
+        from_name = __underscore(from_name)
+        define_method("compose_from_#{from_name}") do |instance|
+          attributes.each do |attr|
+            setter_name = "set_#{attr}"
+            if self.respond_to?(setter_name) && instance.respond_to?(attr)
+              self.send(setter_name, instance.send(attr))
+            else
+              warn %{
+                Builder #{base.class.name} or instance #{instance.class.name} do not respond to expected message: #{attr}."
+              }.strip
+            end
+          end
+
+          self
+        end
+      end
+    end
+
+    module ClassMethods
+      # Stub for documentation
+      #
+      # @param [String] from_name the name of the object you will be composing from.
+      #   IE: compose from 'MiniCooper' => compose_from_mini_cooper(mini_cooper, [:wheels, :doors])
+      # @param  [Array] attributes an array of attributes to be taken from an
+      #   instance of a class to the new class
+      def compose_from(from_name, attributes)
+      end
+
+      def __underscore(string)
+        if string.respond_to? :underscore
+          string.underscore
+        else
+          string.gsub(/::/, '/').
+          gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+          gsub(/([a-z\d])([A-Z])/,'\1_\2').
+          tr("-", "_").
+          downcase
+        end
+      end
+    end
+  end
+end
+

--- a/spec/vandelay/compose_from_spec.rb
+++ b/spec/vandelay/compose_from_spec.rb
@@ -1,0 +1,38 @@
+describe Vandelay::ComposeFrom do
+  describe '#composed_from' do
+    let(:foo) {
+      class Foo
+        def bar
+          'quux'
+        end
+      end
+
+      Foo.new
+    }
+
+    let(:composable) {
+      class FooBuilder
+        extend Vandelay::ComposeFrom
+        attr_reader :bar
+        compose_from 'Foo', [:bar]
+
+        def set_bar(bar)
+          @bar = bar
+        end
+      end
+
+      FooBuilder.new
+    }
+
+    it 'writes compose_from_* instance methods' do
+      expect(composable).to respond_to :compose_from_foo
+    end
+
+    it 'pulls values off the provided instance' do
+      composed_from_foo = composable.compose_from_foo(foo)
+      expect(composed_from_foo).to equal composable
+      expect(composed_from_foo.bar).to eq foo.bar
+    end
+  end
+end
+


### PR DESCRIPTION
Added `ComposeFrom` module which can be extended to create `compose_from_*` methods. Examples of possible usage below.

``` ruby
class Stereo
  def aux_input
    true
  end

  def xm_true
    false
  end

  def am_radio
    true
  end

  def fm_radio
    true
  end

  def bluetooth
    true
  end
end

class CarBuilder
  extend Vandelay::ComposeFrom
  include Vandelay::Buildable

  made_of :style,
          default: :sedan

  made_of :engine, 
          default: :v6

  made_of :doors,
          :speakers,
          default: 2

  made_of audio_inputs, default: false
  compose_from 'Stereo', audio_inputs


  def self.audio_inputs
    [
    :aux_input,
    :xm_radio,
    :am_radio,
    :fm_radio,
    :bluetooth
    ]
  end
end

car_builder = CarBuilder.new
car_builder.compose_from_stereo(stereo).build
```
